### PR TITLE
Allow using backspace to delete annotations

### DIFF
--- a/src/annotator/index.tsx
+++ b/src/annotator/index.tsx
@@ -120,7 +120,7 @@ const ImageAnnotator: FC<ImageAnnotatorProps> = props => {
     const onkeydown = (e: KeyboardEvent) => e.key === 'Control' && svgContainer!.container.classList.add('grabbable');
     const keyup = (e: KeyboardEvent) => {
       if (e.key === 'Control') onblur();
-      if (e.key === 'Delete') Director.instance?.remove();
+      if (e.key === 'Delete' || e.key === 'Backspace') Director.instance?.remove();
       if (e.key === 'Escape') Director.instance?.stopEdit();
     }
     if (svgContainer && props.imageUrl) {


### PR DESCRIPTION
Useful for devices that only have a backspace key (like Macs)